### PR TITLE
ホームをマイページに変更

### DIFF
--- a/resources/views/bkc/drive.blade.php
+++ b/resources/views/bkc/drive.blade.php
@@ -159,6 +159,86 @@
     .sub { color: var(--muted); font-size: 14px; margin-bottom: 18px; }
     .grid { display: grid; gap: 14px; }
     .grid.cards { grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); }
+    
+    /* 詳細表示モーダル */
+    .detail-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+      background: rgba(15,23,42,.45);
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .detail-modal.is-open {
+      display: flex;
+    }
+    .detail-modal-card {
+      width: min(800px, 92vw);
+      max-height: 80vh;
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 20px 60px rgba(15,23,42,.25);
+      overflow-y: auto;
+      backdrop-filter: blur(var(--blur)) saturate(1.05);
+      -webkit-backdrop-filter: blur(var(--blur)) saturate(1.05);
+    }
+    .detail-modal .title {
+      font-size: 20px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      color: var(--ink);
+    }
+    .detail-modal .kvs {
+      line-height: 1.6;
+    }
+    .detail-modal .kvs div:nth-child(odd) {
+      font-weight: 600;
+      color: var(--ink);
+      margin-top: 12px;
+    }
+    .detail-modal .kvs div:nth-child(even) {
+      color: var(--muted);
+      margin-bottom: 8px;
+    }
+    .detail-btn {
+      background: var(--primary);
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      margin-top: 8px;
+    }
+    .detail-btn:hover {
+      background: color-mix(in oklab, var(--primary) 80%, black);
+    }
+    .close-btn {
+      background: var(--muted);
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      margin-top: 16px;
+    }
+    .close-btn:hover {
+      background: color-mix(in oklab, var(--muted) 80%, black);
+    }
+    
+    /* 詳細表示の制限 */
+    .detail-preview {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      line-height: 1.4;
+    }
     .card { background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 14px; box-shadow: 0 8px 28px rgba(15,23,42,0.08);
     /* 常時ガラスUI（可読性を保つため白ベースは維持） */
     backdrop-filter: blur(10px) saturate(1.05);
@@ -384,7 +464,7 @@
         <div class="row" style="justify-content: space-between;">
           <div class="row"><div class="brand">BKC<span>アプリ</span></div></div>
           <nav class="tabs" aria-label="主要ナビゲーション">
-            <a href="/places" class="tabs-link" data-color="blue">ホーム</a>
+            <a href="/places" class="tabs-link" data-color="blue">マイページ</a>
             <a href="/places/type/drive" class="tabs-link" data-color="violet">ドライブ</a>
             <a href="/places/type/karaoke" class="tabs-link" data-color="rose">カラオケ</a>
             <a href="/places/type/izakaya" class="tabs-link" data-color="amber">居酒屋</a>
@@ -398,7 +478,7 @@
       <!-- ================= DRIVE ================= -->
       <section id="drive" class="view" aria-labelledby="drive-title">
         <h2 id="drive-title" class="h1">ドライブ</h2>
-        <p class="sub">上のタブで <strong>ショッピング / 景色 / 息抜き</strong> を切替。各スポットは「場所名・住所・大学からの時間・URL・詳細」を表示します。</p>
+        <p class="sub"></p>
         <input id="drive-shopping" class="tab" type="radio" name="drivecat" checked>
         <input id="drive-scenery"  class="tab" type="radio" name="drivecat">
         <input id="drive-break"    class="tab" type="radio" name="drivecat">
@@ -409,81 +489,99 @@
         </div>
         <div class="drive-views">
           <div id="drv-shopping-list" class="grid cards view">
-            <article class="card"><div class="title">三井アウトレットパーク滋賀竜王</div>
+            <article class="card">
+              <div class="title">三井アウトレットパーク滋賀竜王</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県蒲生郡竜王町大字薬師字砂山1178-694</div>
                 <div>大学からの時間</div><div>30分</div>
                 <div>URL</div><div><a href="https://mitsui-shopping-park.com/mop/shiga/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>近畿最大級で約230ブランドが集まる大型アウトレット。駐車場無料、館内Wi-Fi・EV充電あり。営業時間はショップ10:00–20:00、授業後でも十分回れます。スポーツ・カジュアルからTUMIなどの小物、近江牛グルメまで幅広く楽しめるのが魅力。混みそうな日は夕方からの来場がおすすめです。</div>
+                <div>詳細</div><div class="detail-preview">近畿最大級で約230ブランドが集まる大型アウトレット。駐車場無料、館内Wi-Fi・EV充電あり。営業時間はショップ10:00–20:00、授業後でも十分回れます。スポーツ・カジュアルからTUMIなどの小物、近江牛グルメまで幅広く楽しめるのが魅力。混みそうな日は夕方からの来場がおすすめです。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('shopping-1')">詳細を表示する</button>
             </article>
-            <article class="card"><div class="title">湖の駅　浜大津</div>
+            <article class="card">
+              <div class="title">湖の駅　浜大津</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県大津市浜町2-1</div>
                 <div>大学からの時間</div><div>35分</div>
                 <div>URL</div><div><a href="https://umino-eki.jp/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>滋賀の特産品や地酒がそろうマーケット。フードコートでは近江米を使ったメニューなど手軽に滋賀グルメを味わえます。館内で500円以上の購入で駐車場が3時間無料。屋内で完結するので雨の日の気分転換にも向いています。買い物の後は大津港を散歩したり、ミシガンクルーズや夜のびわこ花噴水を楽しむのもおすすめです。</div>
+                <div>詳細</div><div class="detail-preview">滋賀の特産品や地酒がそろうマーケット。フードコートでは近江米を使ったメニューなど手軽に滋賀グルメを味わえます。館内で500円以上の購入で駐車場が3時間無料。屋内で完結するので雨の日の気分転換にも向いています。買い物の後は大津港を散歩したり、ミシガンクルーズや夜のびわこ花噴水を楽しむのもおすすめです。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('shopping-2')">詳細を表示する</button>
             </article>
-            <article class="card"><div class="title">エイスクエア</div>
+            <article class="card">
+              <div class="title">エイスクエア</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県草津市西渋川1丁目23-1</div>
                 <div>大学からの時間</div><div>15分</div>
                 <div>URL</div><div><a href="https://asquare.ayaha.co.jp/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>JR草津駅西口すぐの駅前モール。アル・プラザ草津に加えて無印良品・ロフト・ユニクロ／GU、大型ホームセンターのディオワールドまでそろいます。駐車場は3,000台・2時間無料（購入で3〜4時間無料に拡大）。雨の日も屋内中心で動きやすく、カフェやレストランも朝から夜まで営業。授業帰りにサクッと休憩したり、休日にまとめ買いとごはんを一気に済ませたりできる学生に人気のスポットです。</div>
+                <div>詳細</div><div class="detail-preview">JR草津駅西口すぐの駅前モール。アル・プラザ草津に加えて無印良品・ロフト・ユニクロ／GU、大型ホームセンターのディオワールドまでそろいます。駐車場は3,000台・2時間無料（購入で3〜4時間無料に拡大）。雨の日も屋内中心で動きやすく、カフェやレストランも朝から夜まで営業。授業帰りにサクッと休憩したり、休日にまとめ買いとごはんを一気に済ませたりできる学生に人気のスポットです。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('shopping-3')">詳細を表示する</button>
             </article>
           </div>
           <div id="drv-scenery-list" class="grid cards view">
-            <article class="card"><div class="title">海津大崎の桜</div>
+            <article class="card">
+              <div class="title">海津大崎の桜</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県高島市マキノ町海津</div>
                 <div>大学からの時間</div><div>1時間45分</div>
                 <div>URL</div><div><a href="https://takashima-kanko.jp/sakura/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>春のドライブなら海津大崎がおすすめ。びわ湖北岸に、約4km・約800本のソメイヨシノが続く桜トンネルがあり、車で走り抜けるだけでも爽快です。桜クルーズを組み合わせれば、陸と湖の両方から楽しめます。満開の週末は交通規制が入り、専用駐車場もないため、徒歩観賞＋今津港／長浜港発の期間限定クルーズを使うのがスムーズ。湖に突き出す岩礁と桜、その奥に竹生島がのぞく景色は「琵琶湖八景」級の迫力で、写真映えも抜群です。渋滞を避けたいなら、平日朝いちか夕方の訪問がねらい目です。</div>
+                <div>詳細</div><div class="detail-preview">春のドライブなら海津大崎がおすすめ。びわ湖北岸に、約4km・約800本のソメイヨシノが続く桜トンネルがあり、車で走り抜けるだけでも爽快です。桜クルーズを組み合わせれば、陸と湖の両方から楽しめます。満開の週末は交通規制が入り、専用駐車場もないため、徒歩観賞＋今津港／長浜港発の期間限定クルーズを使うのがスムーズ。湖に突き出す岩礁と桜、その奥に竹生島がのぞく景色は「琵琶湖八景」級の迫力で、写真映えも抜群です。渋滞を避けたいなら、平日朝いちか夕方の訪問がねらい目です。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('scenery-1')">詳細を表示する</button>
             </article>
-            <article class="card"><div class="title">メタセコイア並木</div>
+            <article class="card">
+              <div class="title">メタセコイア並木</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県高島市</div>
                 <div>大学からの時間</div><div>1時間45分</div>
                 <div>URL</div><div><a href="https://takashima-kanko.jp/spot/metasequoia.html" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>マキノのメタセコイア並木は、約2.4kmに約500本が一直線に続く定番ドライブ道。季節ごとに新緑→深緑→紅葉→雪景色と変わり、車でゆっくり流すだけでも"並木のトンネル"を満喫できます。アクセスは湖西道路〜国道161号が分かりやすく、撮影や休憩は路上駐停車NGなので、道の中央あたりにあるマキノピックランドの無料駐車場へ。混みやすいのは紅葉・新緑の休日なので、平日朝か夕方がねらい目です。並木を抜けたら、併設の直売所や「並木カフェ」でスイーツ休憩できます。</div>
+                <div>詳細</div><div class="detail-preview">マキノのメタセコイア並木は、約2.4kmに約500本が一直線に続く定番ドライブ道。季節ごとに新緑→深緑→紅葉→雪景色と変わり、車でゆっくり流すだけでも"並木のトンネル"を満喫できます。アクセスは湖西道路〜国道161号が分かりやすく、撮影や休憩は路上駐停車NGなので、道の中央あたりにあるマキノピックランドの無料駐車場へ。混みやすいのは紅葉・新緑の休日なので、平日朝か夕方がねらい目です。並木を抜けたら、併設の直売所や「並木カフェ」でスイーツ休憩できます。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('scenery-2')">詳細を表示する</button>
             </article>
-            <article class="card"><div class="title">琵琶湖テラス</div>
+            <article class="card">
+              <div class="title">琵琶湖テラス</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県大津市木戸1547-1</div>
                 <div>大学からの時間</div><div>1時間10分</div>
                 <div>URL</div><div><a href="https://biwako-valley.com/tips/biwako_terrace/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>びわ湖テラスは、山麓駅の大きな駐車場（普通車約1,700台）に停めて、ロープウェイで約5分・標高1,108mの打見山へ。山上の「グランドテラス」「ノーステラス」では、水盤とウッドデッキ越しに北湖から南湖まで一望できて、写真映えも抜群です。余裕があれば、有料の「インフィニティラウンジ」でゆったりくつろいだり、山頂リフトで蓬莱山側の「Café 360」（標高1,174m）まで行って360度の景色を楽しむのもおすすめ。週末は駐車場が分散するので場内循環バスを使うと移動がスムーズ。ロープウェイはおおむね15分間隔・所要約5分なので、朝いちや夕方に合わせて上がると混雑を避けやすく快適に過ごせます。</div>
+                <div>詳細</div><div class="detail-preview">びわ湖テラスは、山麓駅の大きな駐車場（普通車約1,700台）に停めて、ロープウェイで約5分・標高1,108mの打見山へ。山上の「グランドテラス」「ノーステラス」では、水盤とウッドデッキ越しに北湖から南湖まで一望できて、写真映えも抜群です。余裕があれば、有料の「インフィニティラウンジ」でゆったりくつろいだり、山頂リフトで蓬莱山側の「Café 360」（標高1,174m）まで行って360度の景色を楽しむのもおすすめ。週末は駐車場が分散するので場内循環バスを使うと移動がスムーズ。ロープウェイはおおむね15分間隔・所要約5分なので、朝いちや夕方に合わせて上がると混雑を避けやすく快適に過ごせます。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('scenery-3')">詳細を表示する</button>
             </article>
           </div>
           <div id="drv-break-list" class="grid cards view">
-            <article class="card"><div class="title">におの浜</div>
+            <article class="card">
+              <div class="title">におの浜</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県大津市におの浜</div>
                 <div>大学からの時間</div><div>30分</div>
                 <div>URL</div><div><a href="https://www.biwakokisen.co.jp/access/nionohama/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>「大津湖岸なぎさ公園」の中にある気持ちいい水辺スポット。浜大津〜近江大橋のあいだに散策路と芝生が整っていて、ドライブなら周辺の時間貸し駐車場に停めてすぐ歩けます。湖際のコンクリート護岸に腰掛ければ、静かな湖面と比叡・比良の山並みをのんびり眺められて小休憩に最適。中央の「市民プラザ」周辺は広場になっていて、軽く散歩したりベンチで一息つくのにちょうどいいです。特に夕方は空と水の色が変わっていく時間帯が美しく、気分転換できます。</div>
+                <div>詳細</div><div class="detail-preview">「大津湖岸なぎさ公園」の中にある気持ちいい水辺スポット。浜大津〜近江大橋のあいだに散策路と芝生が整っていて、ドライブなら周辺の時間貸し駐車場に停めてすぐ歩けます。湖際のコンクリート護岸に腰掛ければ、静かな湖面と比叡・比良の山並みをのんびり眺められて小休憩に最適。中央の「市民プラザ」周辺は広場になっていて、軽く散歩したりベンチで一息つくのにちょうどいいです。特に夕方は空と水の色が変わっていく時間帯が美しく、気分転換できます。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('break-1')">詳細を表示する</button>
             </article>
-            <article class="card"><div class="title">滋賀県立琵琶湖博物館</div>
+            <article class="card">
+              <div class="title">滋賀県立琵琶湖博物館</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県草津市下物町1091</div>
                 <div>大学からの時間</div><div>25分</div>
                 <div>URL</div><div><a href="https://www.biwahaku.jp/" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>草津からの息抜きドライブがてら、湖岸道路（さざなみ街道）を北上して烏丸半島の滋賀県立琵琶湖博物館へ。湖面や比叡・比良の山並みを眺めながら走るだけで気持ちよく、到着後は琵琶湖の400万年と人の暮らしを学べる展示や、水族展示室・トンネル水槽を楽しめます。駐車場は普通車420台・550円ですが観覧者は無料サービスで実質無料。9:30–17:00（月曜休・最終入館16:00）なので、空きコマや平日昼にも行きやすいです。時間があれば徒歩圏の水生植物公園みずの森との共通券（大学生580円）で、水辺散策までセットにするのがおすすめ。</div>
+                <div>詳細</div><div class="detail-preview">草津からの息抜きドライブがてら、湖岸道路（さざなみ街道）を北上して烏丸半島の滋賀県立琵琶湖博物館へ。湖面や比叡・比良の山並みを眺めながら走るだけで気持ちよく、到着後は琵琶湖の400万年と人の暮らしを学べる展示や、水族展示室・トンネル水槽を楽しめます。駐車場は普通車420台・550円ですが観覧者は無料サービスで実質無料。9:30–17:00（月曜休・最終入館16:00）なので、空きコマや平日昼にも行きやすいです。時間があれば徒歩圏の水生植物公園みずの森との共通券（大学生580円）で、水辺散策までセットにするのがおすすめ。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('break-2')">詳細を表示する</button>
             </article>
-            <article class="card"><div class="title">ラウンドワン浜大津アーカス(スポッチャ)</div>
+            <article class="card">
+              <div class="title">ラウンドワン浜大津アーカス(スポッチャ)</div>
               <div class="kvs" style="margin:8px 0;">
                 <div>住所</div><div>滋賀県大津市浜町2-1</div>
                 <div>大学からの時間</div><div>35分</div>
                 <div>URL</div><div><a href="https://www.round1.co.jp/shop/tenpo/shiga-hamaotsu.html" target="_blank" rel="noopener">公式サイト</a></div>
-                <div>詳細</div><div>大津港そばの「浜大津アーカス」内にあるラウンドワン スタジアム 浜大津アーカス店は、ボウリング・カラオケ・ゲームに加えてスポッチャまで一か所で楽しめる全天候型スポット。駐車場は約500台、ラウンドワン利用中は駐車無料（館内の他店も500円以上で3時間無料）なので車で行きやすく、平日は深夜まで、週末は終日営業の日もあって授業後にも立ち寄りやすいです。アクセスは名神・大津ICから車で約5分、電車なら京阪「びわ湖浜大津」駅すぐ。湖畔ロケーションなので、遊んだ帰りに大津港を軽く散歩してクールダウンできます。</div>
+                <div>詳細</div><div class="detail-preview">大津港そばの「浜大津アーカス」内にあるラウンドワン スタジアム 浜大津アーカス店は、ボウリング・カラオケ・ゲームに加えてスポッチャまで一か所で楽しめる全天候型スポット。駐車場は約500台、ラウンドワン利用中は駐車無料（館内の他店も500円以上で3時間無料）なので車で行きやすく、平日は深夜まで、週末は終日営業の日もあって授業後にも立ち寄りやすいです。アクセスは名神・大津ICから車で約5分、電車なら京阪「びわ湖浜大津」駅すぐ。湖畔ロケーションなので、遊んだ帰りに大津港を軽く散歩してクールダウンできます。</div>
               </div>
+              <button class="detail-btn" onclick="openDetailModal('break-3')">詳細を表示する</button>
             </article>
           </div>
         </div>
@@ -503,6 +601,94 @@
           #drive-break:checked ~ .drive-views #drv-shopping-list,
           #drive-break:checked ~ .drive-views #drv-scenery-list { display: none; }
         </style>
+        
+        <!-- 詳細表示モーダル -->
+        <div id="detail-modal" class="detail-modal">
+          <div class="detail-modal-card">
+            <div class="title" id="modal-title"></div>
+            <div class="kvs" id="modal-content"></div>
+            <button class="close-btn" onclick="closeDetailModal()">閉じる</button>
+          </div>
+        </div>
+        
+        <script>
+          const detailData = {
+            'shopping-1': {
+              title: '三井アウトレットパーク滋賀竜王',
+              content: `
+                <div>詳細</div><div>近畿最大級で約230ブランドが集まる大型アウトレット。駐車場無料、館内Wi-Fi・EV充電あり。営業時間はショップ10:00–20:00、授業後でも十分回れます。スポーツ・カジュアルからTUMIなどの小物、近江牛グルメまで幅広く楽しめるのが魅力。混みそうな日は夕方からの来場がおすすめです。</div>
+              `
+            },
+            'shopping-2': {
+              title: '湖の駅　浜大津',
+              content: `
+                <div>詳細</div><div>滋賀の特産品や地酒がそろうマーケット。フードコートでは近江米を使ったメニューなど手軽に滋賀グルメを味わえます。館内で500円以上の購入で駐車場が3時間無料。屋内で完結するので雨の日の気分転換にも向いています。買い物の後は大津港を散歩したり、ミシガンクルーズや夜のびわこ花噴水を楽しむのもおすすめです。</div>
+              `
+            },
+            'shopping-3': {
+              title: 'エイスクエア',
+              content: `
+                <div>詳細</div><div>JR草津駅西口すぐの駅前モール。アル・プラザ草津に加えて無印良品・ロフト・ユニクロ／GU、大型ホームセンターのディオワールドまでそろいます。駐車場は3,000台・2時間無料（購入で3〜4時間無料に拡大）。雨の日も屋内中心で動きやすく、カフェやレストランも朝から夜まで営業。授業帰りにサクッと休憩したり、休日にまとめ買いとごはんを一気に済ませたりできる学生に人気のスポットです。</div>
+              `
+            },
+            'scenery-1': {
+              title: '海津大崎の桜',
+              content: `
+                <div>詳細</div><div>春のドライブなら海津大崎がおすすめ。びわ湖北岸に、約4km・約800本のソメイヨシノが続く桜トンネルがあり、車で走り抜けるだけでも爽快です。桜クルーズを組み合わせれば、陸と湖の両方から楽しめます。満開の週末は交通規制が入り、専用駐車場もないため、徒歩観賞＋今津港／長浜港発の期間限定クルーズを使うのがスムーズ。湖に突き出す岩礁と桜、その奥に竹生島がのぞく景色は「琵琶湖八景」級の迫力で、写真映えも抜群です。渋滞を避けたいなら、平日朝いちか夕方の訪問がねらい目です。</div>
+              `
+            },
+            'scenery-2': {
+              title: 'メタセコイア並木',
+              content: `
+                <div>詳細</div><div>マキノのメタセコイア並木は、約2.4kmに約500本が一直線に続く定番ドライブ道。季節ごとに新緑→深緑→紅葉→雪景色と変わり、車でゆっくり流すだけでも"並木のトンネル"を満喫できます。アクセスは湖西道路〜国道161号が分かりやすく、撮影や休憩は路上駐停車NGなので、道の中央あたりにあるマキノピックランドの無料駐車場へ。混みやすいのは紅葉・新緑の休日なので、平日朝か夕方がねらい目です。並木を抜けたら、併設の直売所や「並木カフェ」でスイーツ休憩できます。</div>
+              `
+            },
+            'scenery-3': {
+              title: '琵琶湖テラス',
+              content: `
+                <div>詳細</div><div>びわ湖テラスは、山麓駅の大きな駐車場（普通車約1,700台）に停めて、ロープウェイで約5分・標高1,108mの打見山へ。山上の「グランドテラス」「ノーステラス」では、水盤とウッドデッキ越しに北湖から南湖まで一望できて、写真映えも抜群です。余裕があれば、有料の「インフィニティラウンジ」でゆったりくつろいだり、山頂リフトで蓬莱山側の「Café 360」（標高1,174m）まで行って360度の景色を楽しむのもおすすめ。週末は駐車場が分散するので場内循環バスを使うと移動がスムーズ。ロープウェイはおおむね15分間隔・所要約5分なので、朝いちや夕方に合わせて上がると混雑を避けやすく快適に過ごせます。</div>
+              `
+            },
+            'break-1': {
+              title: 'におの浜',
+              content: `
+                <div>詳細</div><div>「大津湖岸なぎさ公園」の中にある気持ちいい水辺スポット。浜大津〜近江大橋のあいだに散策路と芝生が整っていて、ドライブなら周辺の時間貸し駐車場に停めてすぐ歩けます。湖際のコンクリート護岸に腰掛ければ、静かな湖面と比叡・比良の山並みをのんびり眺められて小休憩に最適。中央の「市民プラザ」周辺は広場になっていて、軽く散歩したりベンチで一息つくのにちょうどいいです。特に夕方は空と水の色が変わっていく時間帯が美しく、気分転換できます。</div>
+              `
+            },
+            'break-2': {
+              title: '滋賀県立琵琶湖博物館',
+              content: `
+                <div>詳細</div><div>草津からの息抜きドライブがてら、湖岸道路（さざなみ街道）を北上して烏丸半島の滋賀県立琵琶湖博物館へ。湖面や比叡・比良の山並みを眺めながら走るだけで気持ちよく、到着後は琵琶湖の400万年と人の暮らしを学べる展示や、水族展示室・トンネル水槽を楽しめます。駐車場は普通車420台・550円ですが観覧者は無料サービスで実質無料。9:30–17:00（月曜休・最終入館16:00）なので、空きコマや平日昼にも行きやすいです。時間があれば徒歩圏の水生植物公園みずの森との共通券（大学生580円）で、水辺散策までセットにするのがおすすめ。</div>
+              `
+            },
+            'break-3': {
+              title: 'ラウンドワン浜大津アーカス(スポッチャ)',
+              content: `
+                <div>詳細</div><div>大津港そばの「浜大津アーカス」内にあるラウンドワン スタジアム 浜大津アーカス店は、ボウリング・カラオケ・ゲームに加えてスポッチャまで一か所で楽しめる全天候型スポット。駐車場は約500台、ラウンドワン利用中は駐車無料（館内の他店も500円以上で3時間無料）なので車で行きやすく、平日は深夜まで、週末は終日営業の日もあって授業後にも立ち寄りやすいです。アクセスは名神・大津ICから車で約5分、電車なら京阪「びわ湖浜大津」駅すぐ。湖畔ロケーションなので、遊んだ帰りに大津港を軽く散歩してクールダウンできます。</div>
+              `
+            }
+          };
+          
+          function openDetailModal(id) {
+            const data = detailData[id];
+            if (data) {
+              document.getElementById('modal-title').textContent = data.title;
+              document.getElementById('modal-content').innerHTML = data.content;
+              document.getElementById('detail-modal').classList.add('is-open');
+            }
+          }
+          
+          function closeDetailModal() {
+            document.getElementById('detail-modal').classList.remove('is-open');
+          }
+          
+          // モーダル外をクリックで閉じる
+          document.getElementById('detail-modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+              closeDetailModal();
+            }
+          });
+        </script>
       </section>
     </main>
   </div>

--- a/resources/views/bkc/fleamarket.blade.php
+++ b/resources/views/bkc/fleamarket.blade.php
@@ -382,7 +382,7 @@
         <div class="row" style="justify-content: space-between;">
           <div class="row"><div class="brand">BKC<span>アプリ</span></div></div>
           <nav class="tabs" aria-label="主要ナビゲーション">
-            <a href="/places" class="tabs-link" data-color="blue">ホーム</a>
+            <a href="/places" class="tabs-link" data-color="blue">マイページ</a>
             <a href="/places/type/drive" class="tabs-link" data-color="violet">ドライブ</a>
             <a href="/places/type/karaoke" class="tabs-link" data-color="rose">カラオケ</a>
             <a href="/places/type/izakaya" class="tabs-link" data-color="amber">居酒屋</a>
@@ -396,86 +396,159 @@
       <!-- ================= FLEA MARKET ================= -->
       <section id="fleamarket" class="view" aria-labelledby="fleamarket-title">
         <h2 id="fleamarket-title" class="h1">フリマ（教科書）</h2>
-        <p class="sub">出品 / 買取 の2タブ。<strong>買取はキーワード1つで検索</strong>し、結果からDMできます。詳細は常に表示されます。</p>
-        <input id="sub-sell" class="tab" type="radio" name="fm" checked>
-        <input id="sub-buy" class="tab" type="radio" name="fm">
-        <div class="tabs" style="margin: 10px 0 14px;">
-          <label for="sub-sell" data-color="green">出品</label>
-          <label for="sub-buy" data-color="amber">買取</label>
-        </div>
-        <div id="fm-sell" class="view">
-          <div class="cols">
-            <div class="card">
-              <div class="title">表紙の作成 / 掲載</div>
-              <form>
-                <div class="field"><label>教科書の写真</label><input type="file" accept="image/*" /></div>
-                <div class="field"><label>教科書名</label><input type="text" placeholder="例）線形代数入門" /></div>
-                <div class="field"><label>大学からの距離 / 時間</label><input type="text" placeholder="例）徒歩10分" /></div>
-                <div class="field"><label>金額</label><input type="number" placeholder="例）1500" /></div>
-                <div class="field"><label>お店 / 参考URL</label><input type="url" placeholder="https://example.com" /></div>
-                <div class="field"><label>詳細（利用した授業など）</label><textarea placeholder="例）経済学概論（2024年度）で使用"></textarea></div>
-                <div class="btn-row"><button type="button" class="btn primary">掲載</button><button type="reset" class="btn">消去</button></div>
-              </form>
+        <p class="sub"></p>
+        
+        <div class="grid cards">
+          <article class="card">
+            <div class="title">線形代数入門</div>
+            <div class="meta">¥1,500</div>
+            <div class="kvs" style="margin:10px 0;">
+              <div>著者</div><div>山田太郎</div>
+              <div>科目</div><div>線形代数（基礎）</div>
+              <div>状態</div><div>書き込み少しあり</div>
+              <div>詳細</div><div class="detail-preview">第2版。状態良好で、重要な部分にマーカーが少し入っています。経済学概論（2024年度）で使用しました。</div>
             </div>
-            <div class="card">
-              <div class="title">あなたの掲載一覧（編集・削除）</div>
-              <div class="grid">
-                <article class="card" style="border-style:dashed;">
-                  <div class="title">数学入門</div>
-                  <div class="meta">¥1,500 / 大学から徒歩5分</div>
-                  <div class="btn-row" style="margin-top:8px;"><label for="sell-edit-1" class="btn">編集</label><label for="sell-del-1" class="btn ghost">削除</label></div>
-                  <input id="sell-edit-1" class="toggle" type="checkbox">
-                  <div class="edit-panel">
-                    <form>
-                      <div class="field"><label>教科書名</label><input type="text" value="数学入門" /></div>
-                      <div class="field"><label>金額</label><input type="number" value="1500" /></div>
-                      <div class="field"><label>距離/時間</label><input type="text" value="大学から徒歩5分" /></div>
-                      <div class="field"><label>URL</label><input type="url" placeholder="https://" /></div>
-                      <div class="field"><label>詳細</label><textarea>状態良好。書き込みなし。</textarea></div>
-                      <div class="btn-row"><label for="sell-edit-1" class="btn primary">保存</label><label for="sell-edit-1" class="btn">閉じる</label></div>
-                    </form>
-                  </div>
-                  <input id="sell-del-1" class="toggle" type="checkbox">
-                  <div id="sell-md-del-1" class="modal">
-                    <div class="modal-card">
-                      <div class="title">削除しますか？</div>
-                      <p class="meta">「数学入門」を削除すると元に戻せません。</p>
-                      <div class="btn-row" style="margin-top:10px;"><label for="sell-del-1" class="btn primary">削除する</label><label for="sell-del-1" class="btn">キャンセル</label></div>
-                    </div>
-                  </div>
-                </article>
-              </div>
+            <div class="btn-row" style="margin-top:8px;">
+              <button type="button" class="btn primary" onclick="openDetailModal('linear-algebra')">詳細を見る</button>
             </div>
-          </div>
-          <style>
-            .edit-panel { display:none; margin-top:10px; border:1px dashed var(--line); border-radius:12px; padding:12px; background:#fff; }
-            #sell-edit-1:checked ~ .edit-panel { display:block; }
-            .modal { display:none; position: fixed; inset: 0; z-index: 60; background: rgba(15,23,42,.45); align-items: center; justify-content: center; padding: 20px; }
-            .modal-card { width: min(520px, 92vw); background: #fff; border:1px solid var(--line); border-radius:16px; padding:18px; box-shadow: 0 20px 60px rgba(15,23,42,.25); }
-            #sell-del-1:checked ~ #sell-md-del-1 { display:flex; }
-          </style>
+          </article>
+          
+          <article class="card">
+            <div class="title">統計学入門</div>
+            <div class="meta">¥1,800</div>
+            <div class="kvs" style="margin:10px 0;">
+              <div>著者</div><div>佐藤花子</div>
+              <div>科目</div><div>統計学（基礎）</div>
+              <div>状態</div><div>書き込みなし</div>
+              <div>詳細</div><div class="detail-preview">第3版。ほぼ新品の状態です。統計学概論（2024年度）で使用し、試験も無事に合格できました。</div>
+            </div>
+            <div class="btn-row" style="margin-top:8px;">
+              <button type="button" class="btn primary" onclick="openDetailModal('statistics')">詳細を見る</button>
+            </div>
+          </article>
+          
+          <article class="card">
+            <div class="title">微分積分学</div>
+            <div class="meta">¥2,000</div>
+            <div class="kvs" style="margin:10px 0;">
+              <div>著者</div><div>田中一郎</div>
+              <div>科目</div><div>微分積分（基礎）</div>
+              <div>状態</div><div>書き込みあり</div>
+              <div>詳細</div><div class="detail-preview">第1版。練習問題に解答が書き込まれていますが、学習に役立ちます。数学基礎（2024年度）で使用しました。</div>
+            </div>
+            <div class="btn-row" style="margin-top:8px;">
+              <button type="button" class="btn primary" onclick="openDetailModal('calculus')">詳細を見る</button>
+            </div>
+          </article>
+          
+          <article class="card">
+            <div class="title">経済学概論</div>
+            <div class="meta">¥1,200</div>
+            <div class="kvs" style="margin:10px 0;">
+              <div>著者</div><div>鈴木次郎</div>
+              <div>科目</div><div>経済学（基礎）</div>
+              <div>状態</div><div>書き込み少しあり</div>
+              <div>詳細</div><div class="detail-preview">第4版。重要なポイントにマーカーが入っています。経済学入門（2024年度）で使用し、単位も取得できました。</div>
+            </div>
+            <div class="btn-row" style="margin-top:8px;">
+              <button type="button" class="btn primary" onclick="openDetailModal('economics')">詳細を見る</button>
+            </div>
+          </article>
         </div>
-
-        <div id="fm-buy" class="view">
-          <div class="card">
-            <div class="title">検索（キーワード1つ）</div>
-            <form role="search" class="toolbar" style="margin:8px 0 12px;">
-              <div class="field" style="flex:1 1 260px;"><input type="text" placeholder="例）統計 / 線形代数 / 山田太郎 / 経済学" aria-label="検索キーワード"/></div>
-              <button type="button" class="btn primary">検索</button>
-            </form>
-            <div class="grid cards">
-              <article class="card"><div class="title">1. 統計学入門</div><div class="meta">掲載者：bkc_stats / ¥1,800</div>
-                <div class="kvs" style="margin:10px 0;"><div>著者</div><div>東京太郎 ほか</div><div>科目</div><div>統計学（基礎）</div><div>状態</div><div>書き込み少しあり</div><div>詳細</div><div>第3版。</div></div>
-                <div class="btn-row" style="margin-top:6px;"><a class="btn" href="#">DM</a></div></article>
+        
+        <!-- 詳細モーダル -->
+        <div id="detail-modal" class="modal" style="display: none;">
+          <div class="modal-card">
+            <div class="title" id="modal-title"></div>
+            <div id="modal-content"></div>
+            <div class="btn-row" style="margin-top:16px;">
+              <button type="button" class="btn" onclick="closeDetailModal()">閉じる</button>
             </div>
           </div>
         </div>
+        
         <style>
-          #sub-sell:checked ~ #fm-sell { display:block; }
-          #sub-sell:checked ~ #fm-buy { display:none; }
-          #sub-buy:checked  ~ #fm-sell { display:none; }
-          #sub-buy:checked  ~ #fm-buy { display:block; }
+          .modal { 
+            display: none; 
+            position: fixed; 
+            inset: 0; 
+            z-index: 60; 
+            background: rgba(15,23,42,.45); 
+            align-items: center; 
+            justify-content: center; 
+            padding: 20px; 
+          }
+          .modal-card { 
+            width: min(520px, 92vw); 
+            background: #fff; 
+            border:1px solid var(--line); 
+            border-radius:16px; 
+            padding:18px; 
+            box-shadow: 0 20px 60px rgba(15,23,42,.25); 
+          }
+          #app[data-skin="sakura"] .modal-card {
+            background: var(--card);
+            border: 1px solid rgba(255,255,255,.06);
+            color: var(--ink);
+          }
+          
+          .detail-preview {
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            line-height: 1.4;
+          }
         </style>
+        
+        <script>
+          const detailData = {
+            'linear-algebra': {
+              title: '線形代数入門',
+              content: `
+                <div>詳細</div><div>第2版。状態良好で、重要な部分にマーカーが少し入っています。経済学概論（2024年度）で使用しました。線形変換や固有値・固有ベクトルの部分が特に詳しく説明されており、理解しやすい構成になっています。練習問題も豊富で、基礎から応用まで段階的に学習できるようになっています。</div>
+              `
+            },
+            'statistics': {
+              title: '統計学入門',
+              content: `
+                <div>詳細</div><div>第3版。ほぼ新品の状態です。統計学概論（2024年度）で使用し、試験も無事に合格できました。確率分布から仮説検定まで、基礎から応用まで幅広くカバーしています。図表も豊富で、統計学の概念を視覚的に理解しやすくなっています。練習問題の解答も詳しく載っているので、独学でも十分に学習できます。</div>
+              `
+            },
+            'calculus': {
+              title: '微分積分学',
+              content: `
+                <div>詳細</div><div>第1版。練習問題に解答が書き込まれていますが、学習に役立ちます。数学基礎（2024年度）で使用しました。極限から偏微分まで、大学レベルの微積分を丁寧に解説しています。定理の証明も丁寧で、数学的な思考力を養うのに適しています。書き込みは練習問題の解答のみで、本文には一切書き込みがありません。</div>
+              `
+            },
+            'economics': {
+              title: '経済学概論',
+              content: `
+                <div>詳細</div><div>第4版。重要なポイントにマーカーが入っています。経済学入門（2024年度）で使用し、単位も取得できました。ミクロ経済学とマクロ経済学の基礎を分かりやすく説明しています。現実の経済現象と理論を結びつけた例も豊富で、経済学の理解が深まります。マーカーは重要な定義や公式の部分のみで、読みやすさを損なっていません。</div>
+              `
+            }
+          };
+          
+          function openDetailModal(id) {
+            const data = detailData[id];
+            if (data) {
+              document.getElementById('modal-title').textContent = data.title;
+              document.getElementById('modal-content').innerHTML = data.content;
+              document.getElementById('detail-modal').style.display = 'flex';
+            }
+          }
+          
+          function closeDetailModal() {
+            document.getElementById('detail-modal').style.display = 'none';
+          }
+          
+          // モーダル外をクリックしたら閉じる
+          document.getElementById('detail-modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+              closeDetailModal();
+            }
+          });
+        </script>
       </section>
     </main>
   </div>

--- a/resources/views/bkc/home.blade.php
+++ b/resources/views/bkc/home.blade.php
@@ -382,7 +382,7 @@
         <div class="row" style="justify-content: space-between;">
           <div class="row"><div class="brand">BKC<span>アプリ</span></div></div>
           <nav class="tabs" aria-label="主要ナビゲーション">
-            <a href="/places" class="tabs-link" data-color="blue">ホーム</a>
+            <a href="/places" class="tabs-link" data-color="blue">マイページ</a>
             <a href="/places/type/drive" class="tabs-link" data-color="violet">ドライブ</a>
             <a href="/places/type/karaoke" class="tabs-link" data-color="rose">カラオケ</a>
             <a href="/places/type/izakaya" class="tabs-link" data-color="amber">居酒屋</a>
@@ -399,13 +399,14 @@
         <div class="card" style="max-width:520px; margin: 0 auto;">
           <form>
             <div class="field"><label>メールアドレス</label><input type="email" placeholder="you@example.com" /></div>
-            <div class="field"><label>ユーザーネーム</label><input type="text" placeholder="例）bkc_student" /></div>
+            <div class="field"><label>ニックネーム</label><input type="text" placeholder="例）bkc_student" /></div>
             <div class="field"><label>パスワード</label><input type="password" placeholder="••••••••" /></div>
             <div class="btn-row">
               <a href="/places/type/register" class="btn primary">ログイン</a>
               <a href="/places/type/register" class="btn">新規作成へ</a>
             </div>
             <div class="hint">アカウントをお持ちでない方は「新規作成へ」を押してください。</div>
+            <div class="hint" style="margin-top: 8px;"><a href="#" style="color: var(--primary); text-decoration: underline;">パスワードを忘れた人はこちら</a></div>
           </form>
         </div>
       </section>

--- a/resources/views/bkc/izakaya.blade.php
+++ b/resources/views/bkc/izakaya.blade.php
@@ -382,7 +382,7 @@
         <div class="row" style="justify-content: space-between;">
           <div class="row"><div class="brand">BKC<span>アプリ</span></div></div>
           <nav class="tabs" aria-label="主要ナビゲーション">
-            <a href="/places" class="tabs-link" data-color="blue">ホーム</a>
+            <a href="/places" class="tabs-link" data-color="blue">マイページ</a>
             <a href="/places/type/drive" class="tabs-link" data-color="violet">ドライブ</a>
             <a href="/places/type/karaoke" class="tabs-link" data-color="rose">カラオケ</a>
             <a href="/places/type/izakaya" class="tabs-link" data-color="amber">居酒屋</a>
@@ -396,7 +396,7 @@
       <!-- ================= IZAKAYA ================= -->
       <section id="izakaya" class="view" aria-labelledby="izakaya-title">
         <h2 id="izakaya-title" class="h1">居酒屋</h2>
-        <p class="sub">絞り込み：<strong>安い / 近い / 飲み放題あり</strong>（UIのみ、デモ表示）。</p>
+        <p class="sub"></p>
         <div class="chips" style="margin-bottom:12px;">
           <input id="f-cheap" type="checkbox" class="filter" hidden>
           <label for="f-cheap" class="chip">安い</label>
@@ -405,39 +405,272 @@
           <input id="f-nomihodai" type="checkbox" class="filter" hidden>
           <label for="f-nomihodai" class="chip">飲み放題あり</label>
         </div>
-        <style> input.filter:checked + label.chip { background: #eef2ff; border-color:#c7d2fe; box-shadow: 0 0 0 2px rgba(37,99,235,.12) inset; } </style>
-        <div class="grid cards">
-          <article class="card">
+        <style> 
+          input.filter:checked + label.chip { 
+            background: var(--rose); 
+            border-color: var(--rose); 
+            color: white;
+            box-shadow: 0 0 0 2px rgba(244,63,94,.12) inset; 
+            transform: scale(1.05);
+            font-weight: 700;
+          } 
+          input#f-cheap:checked + label.chip {
+            background: rgba(16,185,129,.2);
+            border-color: rgba(16,185,129,.3);
+            color: #10b981;
+            box-shadow: 0 0 0 2px rgba(16,185,129,.12) inset;
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+          }
+          input#f-near:checked + label.chip {
+            background: rgba(245,158,11,.2);
+            border-color: rgba(245,158,11,.3);
+            color: #f59e0b;
+            box-shadow: 0 0 0 2px rgba(245,158,11,.12) inset;
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+          }
+          input#f-nomihodai:checked + label.chip {
+            background: rgba(244,63,94,.2);
+            border-color: rgba(244,63,94,.3);
+            color: #f43f5e;
+            box-shadow: 0 0 0 2px rgba(244,63,94,.12) inset;
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+          }
+          .card.hidden { display: none; }
+          .category-tags {
+            display: flex;
+            gap: 6px;
+            margin: 8px 0;
+            flex-wrap: wrap;
+          }
+          .category-tag {
+            background: rgba(255,255,255,.15);
+            color: var(--ink);
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            border: 1px solid rgba(255,255,255,.2);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+          }
+          .category-tag.cheap { 
+            background: rgba(16,185,129,.2);
+            border-color: rgba(16,185,129,.3);
+            color: #10b981;
+          }
+          .category-tag.near { 
+            background: rgba(245,158,11,.2);
+            border-color: rgba(245,158,11,.3);
+            color: #f59e0b;
+          }
+          .category-tag.nomihodai { 
+            background: rgba(244,63,94,.2);
+            border-color: rgba(244,63,94,.3);
+            color: #f43f5e;
+          }
+          
+          /* 詳細表示モーダル */
+          .detail-modal {
+            display: none;
+            position: fixed;
+            inset: 0;
+            z-index: 60;
+            background: rgba(15,23,42,.45);
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+          }
+          .detail-modal.is-open {
+            display: flex;
+          }
+          .detail-modal-card {
+            width: min(800px, 92vw);
+            max-height: 80vh;
+            background: var(--card);
+            border: 1px solid var(--line);
+            border-radius: 16px;
+            padding: 20px;
+            box-shadow: 0 20px 60px rgba(15,23,42,.25);
+            overflow-y: auto;
+            backdrop-filter: blur(var(--blur)) saturate(1.05);
+            -webkit-backdrop-filter: blur(var(--blur)) saturate(1.05);
+          }
+          .detail-modal .title {
+            font-size: 20px;
+            font-weight: 700;
+            margin-bottom: 16px;
+            color: var(--ink);
+          }
+          .detail-modal .kvs {
+            line-height: 1.6;
+          }
+          .detail-modal .kvs div:nth-child(odd) {
+            font-weight: 600;
+            color: var(--ink);
+            margin-top: 12px;
+          }
+          .detail-modal .kvs div:nth-child(even) {
+            color: var(--muted);
+            margin-bottom: 8px;
+          }
+          .detail-btn {
+            background: var(--primary);
+            color: white;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 14px;
+            margin-top: 8px;
+          }
+          .detail-btn:hover {
+            background: color-mix(in oklab, var(--primary) 80%, black);
+          }
+          .close-btn {
+            background: var(--muted);
+            color: white;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 14px;
+            margin-top: 16px;
+          }
+          .close-btn:hover {
+            background: color-mix(in oklab, var(--muted) 80%, black);
+          }
+        </style>
+        <script>
+          document.addEventListener('DOMContentLoaded', function() {
+            const filters = document.querySelectorAll('.filter');
+            const cards = document.querySelectorAll('#izakaya-cards .card');
+            
+            filters.forEach(filter => {
+              filter.addEventListener('change', function() {
+                const checkedFilters = Array.from(filters).filter(f => f.checked).map(f => f.id.replace('f-', ''));
+                
+                cards.forEach(card => {
+                  const cardCategories = card.getAttribute('data-categories').split(',');
+                  
+                  if (checkedFilters.length === 0) {
+                    // すべてのボタンが押されていない場合はすべて表示
+                    card.classList.remove('hidden');
+                  } else {
+                    // 選択されたフィルターのいずれかに該当する場合は表示
+                    const hasMatch = checkedFilters.some(filter => cardCategories.includes(filter));
+                    if (hasMatch) {
+                      card.classList.remove('hidden');
+                    } else {
+                      card.classList.add('hidden');
+                    }
+                  }
+                });
+              });
+            });
+          });
+        </script>
+        <div class="grid cards" id="izakaya-cards">
+          <article class="card" data-categories="cheap,near">
             <div class="title">串カツ田中（草津/南草津）</div>
             <div class="meta">BKCから徒歩約20分</div>
+            <div class="category-tags">
+              <span class="category-tag cheap">安い</span>
+              <span class="category-tag near">近い</span>
+            </div>
             <div class="kvs" style="margin:10px 0 6px;">
               <div>飲み放題</div><div>あり（約60種、120分／単品1,782円 税込。学生・女子会向け90分1,001円・120分1,408円などの設定あり）</div>
               <div>価格帯目安</div><div>飲み放題付きコース4,000円〜（例：16品・120分飲み放題付）</div>
               <div>メモ</div><div>店舗により内容・条件が異なるので予約ページで要確認。</div>
             </div>
             <div aria-label="評価" class="star">★★★★☆</div>
+            <button class="detail-btn" onclick="openDetailModal('izakaya-1')">詳細を表示する</button>
           </article>
-          <article class="card">
+          <article class="card" data-categories="cheap,nomihodai">
             <div class="title">ミライザカ（南草津駅前店）</div>
             <div class="meta">BKCから徒歩約40分</div>
+            <div class="category-tags">
+              <span class="category-tag cheap">安い</span>
+              <span class="category-tag nomihodai">飲み放題あり</span>
+            </div>
             <div class="kvs" style="margin:10px 0 6px;">
               <div>飲み放題</div><div>あり（単品120分1,980円 税込。コースは120〜150分飲み放題付が多い）</div>
               <div>価格帯目安</div><div>飲み放題付きコース3,300〜6,000円程度（例：120分3,300円／150分4,000〜6,000円）</div>
               <div>メモ</div><div>クーポンで割引・延長あり。ラストオーダーは30分前が基本。</div>
             </div>
             <div aria-label="評価" class="star">★★★☆☆</div>
+            <button class="detail-btn" onclick="openDetailModal('izakaya-2')">詳細を表示する</button>
           </article>
-          <article class="card">
+          <article class="card" data-categories="near,nomihodai">
             <div class="title">あ・うん</div>
             <div class="meta">草津市野路東6-1-15 エミナール南草津2F（南草津駅から徒歩15分程度）</div>
+            <div class="category-tags">
+              <span class="category-tag near">近い</span>
+              <span class="category-tag nomihodai">飲み放題あり</span>
+            </div>
             <div class="kvs" style="margin:10px 0 6px;">
               <div>営業時間</div><div>17:00～翌3:00（L.O.2:00、ドリンクL.O.2:30）</div>
               <div>総席数</div><div>約50席。掘りごたつ席・座敷席あり。貸切可能人数 40名～。</div>
               <div>予算目安</div><div>通常平均 1,500円程度、宴会時平均 3,000円前後。</div>
             </div>
             <div aria-label="評価" class="star">★★★☆☆</div>
+            <button class="detail-btn" onclick="openDetailModal('izakaya-3')">詳細を表示する</button>
           </article>
         </div>
+        
+        <!-- 詳細表示モーダル -->
+        <div id="detail-modal" class="detail-modal">
+          <div class="detail-modal-card">
+            <div class="title" id="modal-title"></div>
+            <div class="kvs" id="modal-content"></div>
+            <button class="close-btn" onclick="closeDetailModal()">閉じる</button>
+          </div>
+        </div>
+        
+        <script>
+          const detailData = {
+            'izakaya-1': {
+              title: '串カツ田中（草津/南草津）',
+              content: `
+                <div>詳細</div><div>串カツの老舗チェーン店。学生向けの安いプランがあり、コスパが良い。飲み放題の種類も豊富で、学生の飲み会に人気。店舗により内容・条件が異なるので予約ページで要確認。個室もあり、グループでの利用にも適している。</div>
+              `
+            },
+            'izakaya-2': {
+              title: 'ミライザカ（南草津駅前店）',
+              content: `
+                <div>詳細</div><div>南草津駅前の好立地にある居酒屋。飲み放題プランが充実しており、学生の飲み会に最適。クーポンで割引・延長あり。ラストオーダーは30分前が基本。個室もあり、落ち着いた雰囲気で楽しめる。</div>
+              `
+            },
+            'izakaya-3': {
+              title: 'あ・うん',
+              content: `
+                <div>詳細</div><div>南草津駅から徒歩圏内の居酒屋。掘りごたつ席や座敷席があり、和風の雰囲気で落ち着いて楽しめる。貸切も可能で、グループでの利用に適している。飲み放題プランもあり、学生の飲み会に人気。</div>
+              `
+            }
+          };
+          
+          function openDetailModal(id) {
+            const data = detailData[id];
+            if (data) {
+              document.getElementById('modal-title').textContent = data.title;
+              document.getElementById('modal-content').innerHTML = data.content;
+              document.getElementById('detail-modal').classList.add('is-open');
+            }
+          }
+          
+          function closeDetailModal() {
+            document.getElementById('detail-modal').classList.remove('is-open');
+          }
+          
+          // モーダル外をクリックで閉じる
+          document.getElementById('detail-modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+              closeDetailModal();
+            }
+          });
+        </script>
       </section>
     </main>
   </div>

--- a/resources/views/bkc/karaoke.blade.php
+++ b/resources/views/bkc/karaoke.blade.php
@@ -159,6 +159,77 @@
     .sub { color: var(--muted); font-size: 14px; margin-bottom: 18px; }
     .grid { display: grid; gap: 14px; }
     .grid.cards { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+    
+    /* 詳細表示モーダル */
+    .detail-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+      background: rgba(15,23,42,.45);
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .detail-modal.is-open {
+      display: flex;
+    }
+    .detail-modal-card {
+      width: min(800px, 92vw);
+      max-height: 80vh;
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 20px 60px rgba(15,23,42,.25);
+      overflow-y: auto;
+      backdrop-filter: blur(var(--blur)) saturate(1.05);
+      -webkit-backdrop-filter: blur(var(--blur)) saturate(1.05);
+    }
+    .detail-modal .title {
+      font-size: 20px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      color: var(--ink);
+    }
+    .detail-modal .kvs {
+      line-height: 1.6;
+    }
+    .detail-modal .kvs div:nth-child(odd) {
+      font-weight: 600;
+      color: var(--ink);
+      margin-top: 12px;
+    }
+    .detail-modal .kvs div:nth-child(even) {
+      color: var(--muted);
+      margin-bottom: 8px;
+    }
+    .detail-btn {
+      background: var(--primary);
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      margin-top: 8px;
+    }
+    .detail-btn:hover {
+      background: color-mix(in oklab, var(--primary) 80%, black);
+    }
+    .close-btn {
+      background: var(--muted);
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      margin-top: 16px;
+    }
+    .close-btn:hover {
+      background: color-mix(in oklab, var(--muted) 80%, black);
+    }
     .card { background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 14px; box-shadow: 0 8px 28px rgba(15,23,42,0.08);
     /* 常時ガラスUI（可読性を保つため白ベースは維持） */
     backdrop-filter: blur(10px) saturate(1.05);
@@ -382,7 +453,7 @@
         <div class="row" style="justify-content: space-between;">
           <div class="row"><div class="brand">BKC<span>アプリ</span></div></div>
           <nav class="tabs" aria-label="主要ナビゲーション">
-            <a href="/places" class="tabs-link" data-color="blue">ホーム</a>
+            <a href="/places" class="tabs-link" data-color="blue">マイページ</a>
             <a href="/places/type/drive" class="tabs-link" data-color="violet">ドライブ</a>
             <a href="/places/type/karaoke" class="tabs-link" data-color="rose">カラオケ</a>
             <a href="/places/type/izakaya" class="tabs-link" data-color="amber">居酒屋</a>
@@ -396,7 +467,7 @@
       <!-- ================= KARAOKE ================= -->
       <section id="karaoke" class="view" aria-labelledby="karaoke-title">
         <h2 id="karaoke-title" class="h1">カラオケ</h2>
-        <p class="sub">持ち込み可否 / 機種 / 営業時間 / 設備で比較できます（並び替えUIは削除）。</p>
+        <p class="sub"></p>
         <div class="grid cards">
           <article class="card">
             <div class="title">JOYJOY 南草津店</div>
@@ -409,6 +480,7 @@
               <div>設備</div><div>無料Wi‑Fi、ダーツ・ビリヤード併設</div>
             </div>
             <div aria-label="評価" class="star">★★★★☆</div>
+            <button class="detail-btn" onclick="openDetailModal('karaoke-1')">詳細を表示する</button>
           </article>
           <article class="card">
             <div class="title">ジャンカラ 草津駅東口店</div>
@@ -421,6 +493,7 @@
               <div>設備</div><div>店内Wi‑Fi、HDMI貸出など</div>
             </div>
             <div aria-label="評価" class="star">★★★☆☆</div>
+            <button class="detail-btn" onclick="openDetailModal('karaoke-2')">詳細を表示する</button>
           </article>
           <article class="card">
             <div class="title">カラオケStyle 南草津店</div>
@@ -433,8 +506,61 @@
               <div>設備</div><div>プロジェクター付き大部屋やダーツ、コミック読み放題</div>
             </div>
             <div aria-label="評価" class="star">★★★☆☆</div>
+            <button class="detail-btn" onclick="openDetailModal('karaoke-3')">詳細を表示する</button>
           </article>
         </div>
+        
+        <!-- 詳細表示モーダル -->
+        <div id="detail-modal" class="detail-modal">
+          <div class="detail-modal-card">
+            <div class="title" id="modal-title"></div>
+            <div class="kvs" id="modal-content"></div>
+            <button class="close-btn" onclick="closeDetailModal()">閉じる</button>
+          </div>
+        </div>
+        
+        <script>
+          const detailData = {
+            'karaoke-1': {
+              title: 'JOYJOY 南草津店',
+              content: `
+                <div>詳細</div><div>南草津駅から徒歩5分の好立地。個室は清潔で音響も良好。夜はアルコール飲み放題プランがあり、学生の飲み会に人気。ダーツやビリヤードも楽しめるので、カラオケ以外の遊びも充実。平日の昼間は比較的空いており、授業の合間にも利用しやすい。</div>
+              `
+            },
+            'karaoke-2': {
+              title: 'ジャンカラ 草津駅東口店',
+              content: `
+                <div>詳細</div><div>草津駅東口から徒歩3分の便利な立地。24時間営業なので、深夜までカラオケを楽しめる。HDMIケーブルの貸出があるので、スマホやタブレットの画面を大画面に映して動画鑑賞も可能。個室は広めで、グループでの利用に適している。</div>
+              `
+            },
+            'karaoke-3': {
+              title: 'カラオケStyle 南草津店',
+              content: `
+                <div>詳細</div><div>BKCから最も近いカラオケ店。プロジェクター付きの大部屋があり、グループでの利用に最適。コミック読み放題サービスで、カラオケの合間にマンガを読むこともできる。アルコール持ち込みは不可だが、店内でドリンクを購入可能。学生割引もあり、コスパが良い。</div>
+              `
+            }
+          };
+          
+          function openDetailModal(id) {
+            const data = detailData[id];
+            if (data) {
+              document.getElementById('modal-title').textContent = data.title;
+              document.getElementById('modal-content').innerHTML = data.content;
+              document.getElementById('detail-modal').classList.add('is-open');
+            }
+          }
+          
+          function closeDetailModal() {
+            document.getElementById('detail-modal').classList.remove('is-open');
+          }
+          
+          // モーダル外をクリックで閉じる
+          document.getElementById('detail-modal').addEventListener('click', function(e) {
+            if (e.target === this) {
+              closeDetailModal();
+            }
+          });
+        </script>
       </section>
     </main>
   </div>

--- a/resources/views/bkc/mypage.blade.php
+++ b/resources/views/bkc/mypage.blade.php
@@ -382,7 +382,7 @@
         <div class="row" style="justify-content: space-between;">
           <div class="row"><div class="brand">BKC<span>アプリ</span></div></div>
           <nav class="tabs" aria-label="主要ナビゲーション">
-            <a href="/places" class="tabs-link" data-color="blue">ホーム</a>
+            <a href="/places" class="tabs-link" data-color="blue">マイページ</a>
             <a href="/places/type/drive" class="tabs-link" data-color="violet">ドライブ</a>
             <a href="/places/type/karaoke" class="tabs-link" data-color="rose">カラオケ</a>
             <a href="/places/type/izakaya" class="tabs-link" data-color="amber">居酒屋</a>
@@ -395,38 +395,26 @@
     <main>
       <!-- ================= MY PAGE ================= -->
       <section id="mypage" class="view" aria-labelledby="mypage-title">
+        <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:14px;">
         <h2 id="mypage-title" class="h1">マイページ</h2>
-
-        <!-- アカウント行 -->
-        <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;">
-          <div><div class="title" style="margin-bottom:4px;">アカウント</div><div class="meta">ログイン中：<strong>bkc_student</strong>（例）</div></div>
-          <div class="btn-row"><a href="/places" class="btn">ログアウト</a></div>
+          <a href="/places" class="btn" style="background: var(--rose); color: white; border-color: var(--rose);">ログアウト</a>
         </div>
 
-        <!-- パスワード変更 -->
-        <div class="card" style="margin-top:14px; max-width:720px;">
-          <div class="title">パスワード変更</div>
+        <!-- 場所管理 -->
+        <div class="card" style="margin-top:14px;">
+          <div class="title">場所管理</div>
           <div class="btn-row">
-            <a href="/profile" class="btn primary">パスワード変更ページへ</a>
+            <a href="http://localhost:8000/places/create" class="btn primary">新しい場所を追加</a>
+            <a href="http://localhost:8000/places/edit" class="btn primary">場所一覧を見る</a>
           </div>
-        </div>
-
-        <!-- 掲載管理：新規作成 & 一覧/編集/削除 -->
-        <div class="cols" style="margin-top:14px;">
-          <!-- 新規作成 -->
-          <div class="card">
-            <div class="title">新しく掲載を作成</div>
-            <div class="btn-row">
-              <a href="http://localhost:8000/places/create" class="btn primary">掲載作成ページへ</a>
             </div>
-          </div>
 
-          <!-- 一覧 / 編集 / 削除 -->
-          <div class="card">
-            <div class="title">あなたの掲載一覧</div>
-            <div class="btn-row">
-              <a href="/places/edit" class="btn primary">掲載一覧ページへ</a>
-            </div>
+        <!-- フリマ管理 -->
+        <div class="card" style="margin-top:14px;">
+          <div class="title">フリマ管理</div>
+          <div class="btn-row">
+            <a href="#" class="btn primary">新しく出品する</a>
+            <a href="#" class="btn primary">自分の出品を見る</a>
           </div>
         </div>
       </section>

--- a/resources/views/places/create.blade.php
+++ b/resources/views/places/create.blade.php
@@ -190,6 +190,119 @@
     #mpnew-drive-type-shopping:checked + label.chip,
     #mpnew-drive-type-scenery:checked + label.chip,
     #mpnew-drive-type-break:checked + label.chip { background:#eef2ff; border-color:#c7d2fe; box-shadow: 0 0 0 2px rgba(37,99,235,.12) inset; }
+
+    /* Sakuraテーマ（ダークガラス + 桜色グロー） */
+    #app[data-skin="sakura"]{
+      /* ベース色も暗色系に上書き（重要） */
+      --ink:#eaf1ff;
+      --muted:#9fb0c6;
+      --line:rgba(255,255,255,.10);
+      --card:rgba(8,12,20,.52);
+      --card-strong:rgba(8,12,20,.66);
+      --blur:12px;
+
+      /* テーマ色 */
+      --theme-0:#ff6aa9;
+      --theme-1:#ffc1dc;
+      --theme-2:#ffe4ef;
+      --primary:var(--theme-0);
+      color:var(--ink);
+    }
+
+    /* #bg が #app の前にあっても効くように :has で背景を更新 */
+    body:has(#app[data-skin="sakura"]) #bg{
+      background:
+        radial-gradient(1200px 800px at 50% -20%, rgba(255,106,169,.18), transparent 60%),
+        radial-gradient(900px 600px at 0% 30%,   rgba(255,193,220,.18), transparent 60%),
+        radial-gradient(900px 600px at 100% 70%, rgba(255,142,187,.14), transparent 60%),
+        linear-gradient(180deg, #0b0f18 0%, #0a1420 50%, #08121c 100%) !important;
+    }
+    body:has(#app[data-skin="sakura"]) #bg::after{
+      background:
+        radial-gradient(420px 320px at 18% 78%, rgba(255,106,169,.22), transparent 60%),
+        radial-gradient(380px 260px at 80% 22%, rgba(255,193,220,.20), transparent 60%),
+        radial-gradient(280px 240px at 78% 86%, rgba(255,142,187,.16), transparent 60%),
+        radial-gradient(100% 100% at 50% 100%, rgba(255,255,255,.10), transparent 45%);
+      opacity:.9;
+    }
+
+    /* コンポーネントのダークガラス上書き */
+    #app[data-skin="sakura"] header{
+      background:var(--card-strong);
+      border-bottom:1px solid rgba(255,255,255,.08);
+      backdrop-filter:blur(var(--blur)) saturate(1.1);
+      -webkit-backdrop-filter:blur(var(--blur)) saturate(1.1);
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.04), 0 4px 18px rgba(0,0,0,.35);
+    }
+    #app[data-skin="sakura"] .brand span{ color:var(--primary); }
+
+    #app[data-skin="sakura"] .card{
+      background:var(--card);
+      border:1px solid rgba(255,255,255,.06);
+      color:var(--ink);
+      backdrop-filter:blur(var(--blur)) saturate(1.05);
+      -webkit-backdrop-filter:blur(var(--blur)) saturate(1.05);
+      box-shadow:
+        inset 0 0 0 1px rgba(255,255,255,.04),
+        0 1px 0 rgba(255,255,255,.05),
+        0 8px 30px rgba(0,0,0,.45),
+        0 0 0 1.5px rgba(255,122,150,.08),
+        0 0 22px 2px rgba(255,122,150,.10);
+    }
+
+    #app[data-skin="sakura"] .tabs label,
+    #app[data-skin="sakura"] .chip{
+      border-color: rgba(255,255,255,.08);
+      background: rgba(12,18,30,.56);
+      color: #ffffff;
+      box-shadow:
+        inset 0 0 0 1px rgba(255,255,255,.04),
+        0 0 0 2px rgba(255,152,177,.08);
+    }
+    #app[data-skin="sakura"] .tabs label:hover{
+      box-shadow:
+        inset 0 0 0 2px rgba(255,152,177,.16),
+        0 6px 18px rgba(0,0,0,.35);
+    }
+
+    #app[data-skin="sakura"] .btn{
+      background: rgba(12,18,30,.6);
+      border: 1px solid rgba(255,255,255,.10);
+      color: var(--ink);
+    }
+    #app[data-skin="sakura"] .btn.primary{
+      background: var(--primary);
+      border-color: transparent;
+      color: #0b0f18;
+      box-shadow: 0 8px 26px color-mix(in oklab, var(--primary) 35%, black);
+    }
+
+    #app[data-skin="sakura"] form input,
+    #app[data-skin="sakura"] form textarea,
+    #app[data-skin="sakura"] form select{
+      background: rgba(10,16,26,.66);
+      color: var(--ink);
+      border: 1px solid rgba(255,255,255,.10);
+    }
+    #app[data-skin="sakura"] .meta{ color: var(--muted); }
+
+    /* 選択中タブのアウトラインをテーマ色に */
+    #app[data-skin="sakura"] #mpnew-cat-drive:checked ~ .tabs label[for="mpnew-cat-drive"],
+    #app[data-skin="sakura"] #mpnew-cat-karaoke:checked ~ .tabs label[for="mpnew-cat-karaoke"],
+    #app[data-skin="sakura"] #mpnew-cat-izakaya:checked ~ .tabs label[for="mpnew-cat-izakaya"]{
+      outline: 2px solid var(--primary);
+      box-shadow: 0 6px 16px color-mix(in oklab, var(--primary) 35%, black);
+    }
+
+    /* ドライブ種類チップのON表現（Sakuraテーマ） */
+    #app[data-skin="sakura"] #mpnew-drive-type-shopping:checked + label.chip,
+    #app[data-skin="sakura"] #mpnew-drive-type-scenery:checked + label.chip,
+    #app[data-skin="sakura"] #mpnew-drive-type-break:checked + label.chip { 
+      background: rgba(255,106,169,.2); 
+      border-color: rgba(255,106,169,.3); 
+      color: #ffc1dc; 
+      box-shadow: 0 0 0 2px rgba(255,106,169,.12) inset; 
+    }
   </style>
 </head>
 <body>
@@ -197,7 +310,7 @@
   <div id="bg" aria-hidden="true"></div>
 
   <!-- ======= APP WRAPPER ======= -->
-  <div id="app">
+  <div id="app" data-skin="sakura">
     <header>
       <div class="container">
         <div class="row" style="justify-content: space-between;">
@@ -277,6 +390,20 @@
             <div class="field"><label>距離/時間</label><input type="text" name="distance" placeholder="例）大学から徒歩8分" /></div>
             <div class="field"><label>予算</label><input type="text" name="budget" placeholder="例）¥2,500〜¥3,500" /></div>
             <div class="field"><label>特徴</label><input type="text" name="features" placeholder="例）飲み放題あり / 個室 / 喫煙可" /></div>
+            
+            <!-- 絞り込み分類 -->
+            <div class="field"><label>分類</label>
+              <div class="chips">
+                <input id="mpnew-izakaya-cheap" type="checkbox" name="categories[]" value="cheap" class="toggle">
+                <label for="mpnew-izakaya-cheap" class="chip">安い</label>
+                <input id="mpnew-izakaya-near" type="checkbox" name="categories[]" value="near" class="toggle">
+                <label for="mpnew-izakaya-near" class="chip">近い</label>
+                <input id="mpnew-izakaya-nomihodai" type="checkbox" name="categories[]" value="nomihodai" class="toggle">
+                <label for="mpnew-izakaya-nomihodai" class="chip">飲み放題あり</label>
+                        </div>
+              <div class="hint">※ 複数選択可能。絞り込み表示に使用されます。</div>
+                        </div>
+
             <div class="field"><label>URL</label><input type="url" name="url" placeholder="https://example.com" /></div>
             <div class="field"><label>詳細</label><textarea name="description" placeholder="例）席数、予約、注意事項など"></textarea></div>
             <div class="btn-row"><button type="submit" class="btn primary">掲載する</button><button type="reset" class="btn">消去</button></div>

--- a/resources/views/places/edit.blade.php
+++ b/resources/views/places/edit.blade.php
@@ -199,6 +199,121 @@
     #mp-del-drive-1:checked ~ #mp-md-del-drive-1,
     #mp-del-karaoke-1:checked ~ #mp-md-del-karaoke-1,
     #mp-del-izakaya-1:checked ~ #mp-md-del-izakaya-1 { display:flex; }
+
+    /* Sakuraテーマ（ダークガラス + 桜色グロー） */
+    #app[data-skin="sakura"]{
+      /* ベース色も暗色系に上書き（重要） */
+      --ink:#eaf1ff;
+      --muted:#9fb0c6;
+      --line:rgba(255,255,255,.10);
+      --card:rgba(8,12,20,.52);
+      --card-strong:rgba(8,12,20,.66);
+      --blur:12px;
+
+      /* テーマ色 */
+      --theme-0:#ff6aa9;
+      --theme-1:#ffc1dc;
+      --theme-2:#ffe4ef;
+      --primary:var(--theme-0);
+      color:var(--ink);
+    }
+
+    /* #bg が #app の前にあっても効くように :has で背景を更新 */
+    body:has(#app[data-skin="sakura"]) #bg{
+      background:
+        radial-gradient(1200px 800px at 50% -20%, rgba(255,106,169,.18), transparent 60%),
+        radial-gradient(900px 600px at 0% 30%,   rgba(255,193,220,.18), transparent 60%),
+        radial-gradient(900px 600px at 100% 70%, rgba(255,142,187,.14), transparent 60%),
+        linear-gradient(180deg, #0b0f18 0%, #0a1420 50%, #08121c 100%) !important;
+    }
+    body:has(#app[data-skin="sakura"]) #bg::after{
+      background:
+        radial-gradient(420px 320px at 18% 78%, rgba(255,106,169,.22), transparent 60%),
+        radial-gradient(380px 260px at 80% 22%, rgba(255,193,220,.20), transparent 60%),
+        radial-gradient(280px 240px at 78% 86%, rgba(255,142,187,.16), transparent 60%),
+        radial-gradient(100% 100% at 50% 100%, rgba(255,255,255,.10), transparent 45%);
+      opacity:.9;
+    }
+
+    /* コンポーネントのダークガラス上書き */
+    #app[data-skin="sakura"] header{
+      background:var(--card-strong);
+      border-bottom:1px solid rgba(255,255,255,.08);
+      backdrop-filter:blur(var(--blur)) saturate(1.1);
+      -webkit-backdrop-filter:blur(var(--blur)) saturate(1.1);
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.04), 0 4px 18px rgba(0,0,0,.35);
+    }
+    #app[data-skin="sakura"] .brand span{ color:var(--primary); }
+
+    #app[data-skin="sakura"] .card{
+      background:var(--card);
+      border:1px solid rgba(255,255,255,.06);
+      color:var(--ink);
+      backdrop-filter:blur(var(--blur)) saturate(1.05);
+      -webkit-backdrop-filter:blur(var(--blur)) saturate(1.05);
+      box-shadow:
+        inset 0 0 0 1px rgba(255,255,255,.04),
+        0 1px 0 rgba(255,255,255,.05),
+        0 8px 30px rgba(0,0,0,.45),
+        0 0 0 1.5px rgba(255,122,150,.08),
+        0 0 22px 2px rgba(255,122,150,.10);
+    }
+
+    #app[data-skin="sakura"] .tabs label,
+    #app[data-skin="sakura"] .chip{
+      border-color: rgba(255,255,255,.08);
+      background: rgba(12,18,30,.56);
+      color: #ffffff;
+      box-shadow:
+        inset 0 0 0 1px rgba(255,255,255,.04),
+        0 0 0 2px rgba(255,152,177,.08);
+    }
+    #app[data-skin="sakura"] .tabs label:hover{
+      box-shadow:
+        inset 0 0 0 2px rgba(255,152,177,.16),
+        0 6px 18px rgba(0,0,0,.35);
+    }
+
+    #app[data-skin="sakura"] .btn{
+      background: rgba(12,18,30,.6);
+      border: 1px solid rgba(255,255,255,.10);
+      color: var(--ink);
+    }
+    #app[data-skin="sakura"] .btn.primary{
+      background: var(--primary);
+      border-color: transparent;
+      color: #0b0f18;
+      box-shadow: 0 8px 26px color-mix(in oklab, var(--primary) 35%, black);
+    }
+
+    #app[data-skin="sakura"] form input,
+    #app[data-skin="sakura"] form textarea,
+    #app[data-skin="sakura"] form select{
+      background: rgba(10,16,26,.66);
+      color: var(--ink);
+      border: 1px solid rgba(255,255,255,.10);
+    }
+    #app[data-skin="sakura"] .meta{ color: var(--muted); }
+
+    /* 選択中タブのアウトラインをテーマ色に */
+    #app[data-skin="sakura"] #mp-cat-drive:checked ~ .tabs label[for="mp-cat-drive"],
+    #app[data-skin="sakura"] #mp-cat-karaoke:checked ~ .tabs label[for="mp-cat-karaoke"],
+    #app[data-skin="sakura"] #mp-cat-izakaya:checked ~ .tabs label[for="mp-cat-izakaya"]{
+      outline: 2px solid var(--primary);
+      box-shadow: 0 6px 16px color-mix(in oklab, var(--primary) 35%, black);
+    }
+
+    /* 編集パネルとモーダル（Sakuraテーマ） */
+    #app[data-skin="sakura"] .edit-panel {
+      background: var(--card);
+      border: 1px solid rgba(255,255,255,.06);
+      color: var(--ink);
+    }
+    #app[data-skin="sakura"] .modal-card {
+      background: var(--card);
+      border: 1px solid rgba(255,255,255,.06);
+      color: var(--ink);
+    }
   </style>
 </head>
 <body>
@@ -206,7 +321,7 @@
   <div id="bg" aria-hidden="true"></div>
 
   <!-- ======= APP WRAPPER ======= -->
-  <div id="app">
+  <div id="app" data-skin="sakura">
     <header>
       <div class="container">
         <div class="row" style="justify-content: space-between;">


### PR DESCRIPTION
パスワード変更ページの消去
ログイン画面にパスワードを忘れた人向けのページの追加
ホームタブをマイページタブに変更
マイページをダッシュボードのように掲載したものの管理ができるように作成(フリマの出品)
居酒屋ページの近い、安い、飲み放題ありで絞り込みができるようにする。